### PR TITLE
IMusicPresenter の namespace が誤っていたので修正する

### DIFF
--- a/Assets/Scripts/CAFU/Music/BackwardCompatibility.meta
+++ b/Assets/Scripts/CAFU/Music/BackwardCompatibility.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cfedb97e8060461aad410e7fe338d69e
+timeCreated: 1518501645

--- a/Assets/Scripts/CAFU/Music/BackwardCompatibility/Presentation.meta
+++ b/Assets/Scripts/CAFU/Music/BackwardCompatibility/Presentation.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d8d88cda39e34fd59f12405c756fea06
+timeCreated: 1518501645

--- a/Assets/Scripts/CAFU/Music/BackwardCompatibility/Presentation/Presenter.meta
+++ b/Assets/Scripts/CAFU/Music/BackwardCompatibility/Presentation/Presenter.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f8cafe46355c40f5b20e70a144c8cf00
+timeCreated: 1518501645

--- a/Assets/Scripts/CAFU/Music/BackwardCompatibility/Presentation/Presenter/MusicPresenter.cs
+++ b/Assets/Scripts/CAFU/Music/BackwardCompatibility/Presentation/Presenter/MusicPresenter.cs
@@ -2,8 +2,11 @@
 
 // ReSharper disable UnusedMember.Global
 
+using System;
+
 namespace Assets.Scripts.CAFU.Music.Presentation.Presenter {
 
+    [Obsolete("Please use 'CAFU.Music.Presentation.Presenter.IMusicPresenter<TEnum>' instead of this interface.")]
     public interface IMusicPresenter<in TEnum> : global::CAFU.Music.Presentation.Presenter.IMusicPresenter<TEnum>
         where TEnum : struct {
 

--- a/Assets/Scripts/CAFU/Music/BackwardCompatibility/Presentation/Presenter/MusicPresenter.cs
+++ b/Assets/Scripts/CAFU/Music/BackwardCompatibility/Presentation/Presenter/MusicPresenter.cs
@@ -1,0 +1,12 @@
+﻿
+
+// ReSharper disable UnusedMember.Global
+
+namespace Assets.Scripts.CAFU.Music.Presentation.Presenter {
+
+    public interface IMusicPresenter<in TEnum> : global::CAFU.Music.Presentation.Presenter.IMusicPresenter<TEnum>
+        where TEnum : struct {
+
+    }
+
+}

--- a/Assets/Scripts/CAFU/Music/BackwardCompatibility/Presentation/Presenter/MusicPresenter.cs.meta
+++ b/Assets/Scripts/CAFU/Music/BackwardCompatibility/Presentation/Presenter/MusicPresenter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2c12411a3b5445f0ad97e69131ebc5f8
+timeCreated: 1518501646

--- a/Assets/Scripts/CAFU/Music/Presentation/Presenter/MusicPresenter.cs
+++ b/Assets/Scripts/CAFU/Music/Presentation/Presenter/MusicPresenter.cs
@@ -2,7 +2,7 @@
 using CAFU.Core.Presentation.Presenter;
 // ReSharper disable UnusedMember.Global
 
-namespace Assets.Scripts.CAFU.Music.Presentation.Presenter {
+namespace CAFU.Music.Presentation.Presenter {
 
     public interface IMusicPresenter<in TEnum> : IPresenter where TEnum : struct {
 


### PR DESCRIPTION
* Rider で自動生成すると、ディレクトリ構造をそのまま namespace にしてくれちゃうので、直さないとダメでした。