### PR TITLE
Clean instance OnDestroy

### DIFF
--- a/Assets/Scripts/Domain/Component/MusicPlayer.cs
+++ b/Assets/Scripts/Domain/Component/MusicPlayer.cs
@@ -40,6 +40,11 @@ namespace CAFU.Music.Domain.Component
             AudioSource.playOnAwake = false;
         }
 
+        private void OnDestroy()
+        {
+            HasInstalled = false;
+        }
+
         public void Inject(IMusicModel musicModel)
         {
             MusicModel = musicModel;


### PR DESCRIPTION
## What

* Fixes #29 
* If the initialization completed flag is not turned off, initialization processing does not go through in the second and subsequent times.